### PR TITLE
stream read

### DIFF
--- a/feedwatcher.js
+++ b/feedwatcher.js
@@ -44,7 +44,7 @@ export default class FeedWatcher extends EventEmitter {
         return new Promise(async (resolve, reject) => {
             let response = await fetch(this._feed).catch(reject);
 
-            if (response.status !== 200) {
+            if (!response || response.status !== 200) {
                 return reject(new Error('Bad status code'));
             }
 
@@ -56,14 +56,17 @@ export default class FeedWatcher extends EventEmitter {
             });
 
             feedparser.on('error', reject);
+            var items = [];
             feedparser.on('readable', function () {
-                var items = [];
+                var stream = this
                 var item;
                 try {
-                    while ((item = this.read())) {
+                    while (null !== (item = stream.read())) {
                         items.push(item);
                     }
                 } catch (error) {}
+            });
+            feedparser.on('end', () => {
                 resolve(items);
             });
 


### PR DESCRIPTION
[Doc](https://nodejs.org/api/stream.html#readablereadsize) :
> When reading a large file .read() may return null, having consumed all buffered content so far, but there is still more data to come not yet buffered.

so add 'end' event to avoid the variable items length has just one.